### PR TITLE
Fix bug in ecm computation

### DIFF
--- a/R/ecm.R
+++ b/R/ecm.R
@@ -49,11 +49,8 @@ ecm <- function(y,X,output = TRUE)
   dy <- diff(y,1)
   dX <- if (m.X > 1) apply(X,2,"diff",1) else diff(X,1)
   res <- residuals(lm(y ~ X - 1))
-  ECM <- res[-1]
+  ECM <- res[-length(res)]
   lm.fit <- lm(dy ~ dX + ECM - 1)
-  lm.sum <- summary(lm.fit)
-  lm.sum$coefficients[m.X + 1,1] <- -lm.sum$coefficients[m.X + 1,1]
-  coefs <- lm.sum$coefficients
-  if (output) print(lm.sum)
-  ecm <- lm.sum
+  if (output) print(summary(lm.fit))
+  ecm <- lm.fit
 }


### PR DESCRIPTION
Hello Debin,

I took a quick look at your packages, especially the ecm function, and noticed that the results were not quite correct (although not very diverging most of the time).
The bug was a tricky one (hard to notice by eye) on line 52. It was removing the first observation instead of the last one, trying to create the lagged variable. This resulted to estimate the final ecm with the ect (error correctio term) in levels.
I also allowed the "lm" model to be returned by the function and left the "output" to indicate if the "summary" of the "lm" model will be printed out.

Thank you for your collaboration.